### PR TITLE
core/types: define specified types, intial wip of ssz definitions

### DIFF
--- a/core/types/beacon.go
+++ b/core/types/beacon.go
@@ -1,3 +1,19 @@
+//Copyright (c) 2019, The go-ethereum Authors. All rights reserved.
+// This file is part of the firefly library.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//* Redistributions of source code must retain the above copyright
+//notice, this list of conditions and the following disclaimer.
+//* Redistributions in binary form must reproduce the above copyright
+//notice, this list of conditions and the following disclaimer in the
+//documentation and/or other materials provided with the distribution.
+//* Neither the name of The go-ethereum Authors nor the
+//names of its contributors may be used to endorse or promote products
+//derived from this software without specific prior written permission.
+//
+// Package types contains data types related to Ethereum 2.0 consensus.
+// See https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md//data-structures
 package types
 
 // Beacon transactions

--- a/core/types/beacon.go
+++ b/core/types/beacon.go
@@ -1,0 +1,116 @@
+package types
+
+// Beacon transactions
+
+type ProposerSlashing struct {
+	proposerIndex uint64            `ssz:"uint64"`    // Proposer index
+	header1       BeaconBlockHeader `ssz:"container"` // First block header
+	header2       BeaconBlockHeader `ssz:"container"` // Second block header
+}
+
+type AttesterSlashing struct {
+	slashableAttestation1 SlashableAttestation `ssz:"container"` // First slashable attestation
+	slashableAttestation2 SlashableAttestation `ssz:"container"` // Second slashable attestation
+}
+
+type Attestation struct {
+	aggregationBitfield []byte          `ssz:"bytes"`     // Attester aggregation bitfield
+	data                AttestationData `ssz:"container"` // Attestation data
+	custodyBitfield     bytes           `ssz:"bytes"`     // Custody bitfield
+	aggregateSignature  [96]byte        `ssz:"bytes96"`   // BLS aggregate signature
+}
+
+type Deposit struct {
+	proof       [DepositContractTreeDepth][32]byte `ssz:"list32:bytes32"` // Branch in the deposit tree
+	index       uint64                             `ssz:"uint64"`         // Index in the deposit tree
+	depositData DepositData                        `ssz:"container"`      // Data
+}
+
+type VoluntaryExit struct {
+	epoch          uint64   `ssz:"uint64"`  // Minimum epoch for processing exit
+	validatorIndex uint64   `ssz:"uint64"`  // Index of the exiting validator
+	signature      [96]byte `ssz:"bytes96"` // Validator signature
+}
+
+type Transfer struct {
+	sender    uint64   `ssz:"uint64"`  // Sender index
+	recipient uint64   `ssz:"uint64"`  // Recipient index
+	amount    uint64   `ssz:"uint64"`  // Amount in Gwei
+	fee       uint64   `ssz:"uint64"`  // Fee in Gwei for block proposer
+	slot      uint64   `ssz:"uint64"`  // Inclusion slot
+	pubkey    [48]byte `ssz:"bytes48"` // Sender withdrawal pubkey
+	signature [96]byte `ssz:"bytes96"` // Sender signature
+}
+
+// Beacon blocks
+
+type BeaconBlockBody struct {
+	randaoReveal      [96]byte           `ssz:"bytes96"`
+	eth1Data          Eth1Data           `ssz:"container"`
+	proposerSlashings []ProposerSlashing `ssz:"list:container"`
+	attesterSlashings []AttesterSlashing `ssz:"list:container"`
+	attestations      []Attestation      `ssz:"list:container"`
+	deposits          []Deposit          `ssz:"list:container"`
+	voluntary_exits   []VoluntaryExit    `ssz:"list:container"`
+	transfers         []Transfer         `ssz:"list:container"`
+}
+
+type BeaconBlock struct {
+	// Header
+	slot              uint64          `ssz:"uint64"`
+	previousBlockRoot root            `ssz:"bytes32"`
+	stateRoot         root            `ssz:"bytes32"`
+	body              BeaconBlockBody `ssz:"container"`
+	signature         [96]byte        `ssz:"bytes96"`
+}
+
+//   Beacon state
+
+type BeaconState struct {
+	// Misc
+	slot        uint64 `ssz:"uint64"`
+	genesisTime uint64 `ssz:"uint64"`
+	fork        Fork   `ssz:"container"` // For versioning hard forks
+
+	// Validator registry
+	validatorRegistry            []Validator `ssz:"list:container"`
+	validatorBalances            []uint64    `ssz:"uint64"`
+	validatorRegistryUpdateEpoch uint64      `ssz:"uint64"`
+
+	// Randomness and committees
+	latestRandaoMixes           [LatestRandaoMixesLength][32]byte `ssz:"bytes32"`
+	previousShufflingStartShard uint64                            `ssz:"uint64"`
+	currentShufflingStartShard  uint64                            `ssz:"uint64"`
+	previousShufflingEpoch      uint64                            `ssz:"uint64"`
+	currentShufflingEpoch       uint64                            `ssz:"uint64"`
+	previousShufflingSeed       [32]byte                          `ssz:"bytes32"`
+	currentShufflingSeed        [32]byte                          `ssz:"bytes32"`
+
+	// Finality
+	previousEpochAttestations []PendingAttestation `ssz:"list:container"`
+	currentEpochAttestations  []PendingAttestation `ssz:"list:container"`
+	previousJustifiedEpoch    uint64               `ssz:"uint64"`
+	currentJustifiedEpoch     uint64               `ssz:"uint64"`
+	previousJustifiedRoot     root                 `ssz:"bytes32"`
+	currentJustifiedRoot      root                 `ssz:"bytes32"`
+	justificationBitfield     uint64               `ssz:"uint64"`
+	finalizedEpoch            uint64               `ssz:"uint64"`
+	finalizedRoot             [32]byte             `ssz:"bytes32"`
+
+	// Recent state
+	latestCrosslinks [ShardCount]Crosslink
+
+	latestBlockRoots       [SlotsPerHistoricalRoot]root       `ssz:"list:container,8192"`
+	latestStateRoots       [SlotsPerHistoricalRoot]root       `ssz:"list:container,8192"`
+	latestActiveIndexRoots [LatestActiveIndexRootsLength]root `ssz:"list:container,8192"`
+	// Balances slashed at every withdrawal period
+	latestSlashedBalances [LatestSlashedExitLength]uint64 `ssz:"uint64"`
+	// `latest_block_header.state_root == ZERO_HASH` temporarily
+	latestBlockHeader BeaconBlockHeader `ssz:"container"`
+	historicalRoots   []root            `ssz:"list:bytes32"`
+
+	// Ethereum 1.0 chain data
+	latestEth1Data Eth1Data       `ssz:"container"`
+	eth1DataVotes  []Eth1DataVote `ssz:"list:container"`
+	depositIndex   uint64         `ssz:"uint64"`
+}

--- a/core/types/constants.go
+++ b/core/types/constants.go
@@ -1,3 +1,20 @@
+//Copyright (c) 2019, The go-ethereum Authors. All rights reserved.
+// This file is part of the firefly library.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//* Redistributions of source code must retain the above copyright
+//notice, this list of conditions and the following disclaimer.
+//* Redistributions in binary form must reproduce the above copyright
+//notice, this list of conditions and the following disclaimer in the
+//documentation and/or other materials provided with the distribution.
+//* Neither the name of The go-ethereum Authors nor the
+//names of its contributors may be used to endorse or promote products
+//derived from this software without specific prior written permission.
+//
+// Package types contains data types related to Ethereum 2.0 consensus.
+// See https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md//data-structures
+
 package types
 
 const (

--- a/core/types/constants.go
+++ b/core/types/constants.go
@@ -1,0 +1,76 @@
+package types
+
+const (
+
+	// Misc
+	ShardCount                 = 1024 // (= 1,024)
+	TargetCommitteeSize        = 128  // (= 128)
+	MaxBalanceChurnQuotient    = 32   // (= 32)
+	MaxIndicesPerSlashableVote = 4096 // (= 4,096)
+	MaxExitDequeusPerEpoch     = 4    //(= 4)
+	ShuffleRoundCount          = 90
+
+	// Deposit contract
+	//  TBD: DepositContractAddress
+	DepositContractTreeDepth = 32 // (= 32)
+
+	// Gwei values
+	MinDepositAmountGwei           = 1000000000  // (= 1,000,000,000) 	Gwei
+	MaxDepositAmountGwei           = 32000000000 // (= 32,000,000,000) 	Gwei
+	ForkChoiceBalanceIncrementGwei = 1000000000  // (= 1,000,000,000) 	Gwei
+	EjectionBalanceGwei            = 16000000000 //(= 16,000,000,000) 	Gwei
+
+	//Time parameters
+	SecondPerSlot                    = 6    // 6 seconds
+	MinAttestationInclusiondDelay    = 4    //(= 4) 	slots 	24 seconds
+	SlotsPerEpoch                    = 64   // (= 64) 	slots 	6.4 minutes
+	MinSeedLookahead                 = 1    // (= 1) 	epochs 	6.4 minutes
+	ActivationExitDelay              = 4    // (= 4) 	epochs 	25.6 minutes
+	EpochsPerEth1VotingPeriod        = 16   // (= 16) 	epochs 	~1.7 hours
+	SlotsPerHistoricalRoot           = 8192 // (= 8,192) 	slots 	~13 hours
+	MinValidatorWithdrawabilityDelay = 256  // (= 256) 	epochs 	~27 hours
+	PersistentCommitteePeriod        = 2048 // (= 2,048) 	epochs 	9 days
+
+	// State list lengths
+	LatestRandaoMixesLength      = 8192 // epochs  ~36 days
+	LatestActiveIndexRootsLength = 8192 // epochs  ~36 days
+	LatestShasledExitLength      = 8192 // epochs  ~36 days
+
+	//Reward and penalty quotients
+	BaseRewardQuotient                 = 32        // 2**5 (= 32)
+	WhistleblowerRewardQuotient        = 512       // 2**9 (= 512)
+	AttestationInclusionRewardQuotient = 8         // 2**3 (= 8)
+	InactivityPenaltyQuotient          = 0x1000000 // 2**24 (= 16,777,216)
+	MinPenaltyQuotient                 = 32        // 2**5 (= 32)
+
+	//Max transactions per block
+	MaxProposesSlashings = 16  // 2**4 (= 16)
+	MaxAttesterSlashings = 1   // 2**0 (= 1)
+	MaxAttestations      = 128 // 2**7 (= 128)
+	MaxDeposits          = 16  // 2**4 (= 16)
+	MaxVoluntaryExits    = 16  // 2**4 (= 16)
+	MaxTransfers         = 16  // 2**4 (= 16)
+)
+const (
+	// Signature domains
+
+	DomainBeaconBLock   = iota // 0
+	DomainRandao        = iota // 1
+	DomainAttestation   = iota // 2
+	DomainDeposit       = iota // 3
+	DomainVoluntaryExit = iota // 4
+	DomainTransfer      = iota // 5
+)
+
+var (
+
+	//Initial values
+	GenesisForkVersion      = 0
+	GenesisSlot             = 0x100000000 // 4294967296
+	GenesisEpoch            = GenesisSlot / SlotsPerEpoch
+	GenesisStartShard       = 0
+	FarFutureEpoch          = 0xffffffffffffffff //2**64 - 1
+	ZeroHash                [32]byte
+	EmptySignature          [96]byte
+	BlsWithdrawalPrefixByte = byte(0)
+)

--- a/core/types/misc.go
+++ b/core/types/misc.go
@@ -1,0 +1,109 @@
+//Copyright (c) 2019, The go-ethereum Authors. All rights reserved.
+// This file is part of the firefly library.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions are met:
+//* Redistributions of source code must retain the above copyright
+//notice, this list of conditions and the following disclaimer.
+//* Redistributions in binary form must reproduce the above copyright
+//notice, this list of conditions and the following disclaimer in the
+//documentation and/or other materials provided with the distribution.
+//* Neither the name of The go-ethereum Authors nor the
+//names of its contributors may be used to endorse or promote products
+//derived from this software without specific prior written permission.
+//
+// Package types contains data types related to Ethereum 2.0 consensus.
+// See https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md//data-structures
+
+package types
+
+type Fork struct {
+	previousVersion [4]byte `ssz:"bytes4"` // Previous fork version
+	currentVersion  [4]byte `ssz:"bytes4"` // Current fork version
+	epoch           uint64  `ssz:"uint64"` // Fork epoch number
+}
+
+type Crosslink struct {
+	epoch             uint64   `ssz:"uint64"`  // Epoch number
+	crosslinkDataRoot [32]byte `ssz:"bytes32"` // Shard data since the previous crosslink
+}
+
+type Eth1Data struct {
+	depositRoot [32]byte `ssz:"bytes32"` // Root of the deposit tree
+	blockHash   [32]byte `ssz:"bytes32"` // Block hash
+}
+
+type Eth1DataVote struct {
+	eth1Data  Eth1Data `ssz:"container"` // Data being voted for
+	voteCount uint64   `ssz:"uint64"`    // Vote count
+}
+
+type AttestationData struct {
+	// LMD GHOST vote
+	slot            uint64   `ssz:"uint64"`
+	beaconBlockRoot [32]byte `ssz:"bytes32"`
+
+	// FFG vote
+	sourceEpoch uint64   `ssz:"uint64"`
+	sourceRoot  [32]byte `ssz:"bytes32"`
+	targetRoot  [32]byte `ssz:"bytes32"`
+
+	// Crosslink vote
+	shard             uint64    `ssz:"uint64"`
+	previousCrosslink Crosslink `ssz:"container"`
+	crosslinkDataRoot [32]byte  `ssz:"bytes32"`
+}
+
+type AttestationDataAndCustodyBit struct {
+	data       AttestationData `ssz:"container"` // Attestation data
+	custodyBit bool            `ssz:"bool"`      // Custody bit
+}
+
+type SlashableAttestation struct {
+	validatorIndices   []uint64        `ssz:"list:uint64"` // Validator indices
+	data               AttestationData `ssz:"container"`   // Attestation data
+	custodyBitfield    []byte          `ssz:"bytes"`       // Custody bitfield
+	aggregateSignature [96]byte        `ssz:"bytes96"`     // Aggregate signature
+}
+
+type DepositInput struct {
+	pubkey                [48]byte `ssz:"bytes48"` // BLS pubkey
+	withdrawalCredentials [32]byte `ssz:"bytes32"` // Withdrawal credentials
+	proofOfPossession     [96]byte `ssz:"bytes96"` // A BLS signature of this `DepositInput`
+}
+
+type DepositData struct {
+	amount       uint64       `ssz:"uint64"`    // Amount in Gwei
+	timestamp    uint64       `ssz:"uint64"`    // Timestamp from deposit contract
+	depositInput DepositInput `ssz:"container"` // Deposit input
+}
+
+type BeaconBlockHeader struct {
+	slot                uint64   `ssz:"uint64"`
+	previous_block_root [32]byte `ssz:"bytes32"`
+	state_root          [32]byte `ssz:"bytes32"`
+	blockBodyRoot       [32]byte `ssz:"bytes32"`
+	signature           [96]byte `ssz:"bytes96"`
+}
+
+type Validator struct {
+	pubkey                [48]byte `ssz:"bytes48"` // BLS public key
+	withdrawalCredentials [32]byte `ssz:"bytes32"` // Withdrawal credentials
+	activationEpoch       uint64   `ssz:"uint64"`  // Epoch when validator activated
+	exitEpoch             uint64   `ssz:"uint64"`  // Epoch when validator exited
+	withdrawableEpoch     uint64   `ssz:"uint64"`  // Epoch when validator is eligible to withdraw
+	initiatedExit         bool     `ssz:"bool"`    // Did the validator initiate an exit
+	slashed               bool     `ssz:"bool"`    // Was the validator slashed
+}
+
+type PendingAttestation struct {
+	aggregationBitfield []byte          `ssz:"bytes"`     // Attester aggregation bitfield
+	data                AttestationData `ssz:"container"` // Attestation data
+	custodyBitfield     bytes           `ssz:"bytes"`     // Custody bitfield
+	inclusionSlot       uint64          `ssz:"uint64"`    // Inclusion slot
+}
+type root [32]byte //`ssz:"bytes32"`
+type HistoricalBatch struct {
+	blockRoots [SlotsPerHistoricalRoot]root // Block roots
+	stateRoots [SlotsPerHistoricalRoot]root // State roots
+}


### PR DESCRIPTION
This is a work in progress. Contains the definitions for the datatypes and constants defined in the spec. 
It also contains the _start_ of a ssz definition for the types. I'll be iterating on the ssz code generator, and the ssz specification syntax. 
It also does not use any pointers, we will probably want to change that around a bit. All constants are defined as raw ints, we willl probably want to use `big.Int` later on. 